### PR TITLE
Add advanced BTC strategy bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,15 @@
 This repository contains two small Python packages used to demonstrate a
 simple Meta-Net trading system and a minimal application called `STR_ONE`.
 
-* **META_NET** implements ``MetaNetTrader``.  The class features a
+* **META_NET** implements ``MetaNetTrader``. The class features a
   ``backtest()`` method that generates random price data and compares the
   strategy's return with a buy-and-hold approach.
 * **STR_ONE** provides ``StrOneApp`` which stores question/answer pairs in a
-  SQLite database.
+  SQLite database and exposes ``MetaNetManager`` with pluggable trading bots.
 
 Run ``python -m py_compile`` on the modules or execute the short examples in
-the tests to see both components in action.
+the tests to see both components in action. Bots live in ``str_one.bots``; the
+included ``TrendFollowingBot``, ``BreakoutStrategyBot`` and ``MeanReversionBot``
+demonstrate how to feed signals into the manager. A more advanced example,
+``BTC4H5MBot``, shows how to adapt a real trading script to the same
+interface.

--- a/STR_ONE/str_one/__init__.py
+++ b/STR_ONE/str_one/__init__.py
@@ -1,5 +1,27 @@
 """STR_ONE package."""
 
-__all__ = ['StrOneApp']
+__all__ = [
+    'StrOneApp',
+    'MetaNetManager',
+    'receive_signal',
+    'compute_global_signal',
+    'reset_signals',
+    'get_signals_state',
+    'TrendFollowingBot',
+    'BreakoutStrategyBot',
+    'MeanReversionBot',
+    'BTC4H5MBot',
+]
 
 from .main import StrOneApp
+from .metanet_manager import (
+    MetaNetManager,
+    compute_global_signal,
+    get_signals_state,
+    receive_signal,
+    reset_signals,
+)
+from .bots.trend_following import TrendFollowingBot
+from .bots.breakout_strategy import BreakoutStrategyBot
+from .bots.mean_reversion import MeanReversionBot
+from .bots.btc4h5m import BTC4H5MBot

--- a/STR_ONE/str_one/bots/__init__.py
+++ b/STR_ONE/str_one/bots/__init__.py
@@ -1,0 +1,33 @@
+"""Collection of simple trading bots used by MetaNetManager."""
+
+__all__ = [
+    'TrendFollowingBot',
+    'apply_strategy',
+    'generate_signal',
+    'BreakoutStrategyBot',
+    'apply_breakout_strategy',
+    'generate_breakout_signal',
+    'MeanReversionBot',
+    'apply_mean_reversion_strategy',
+    'generate_mean_reversion_signal',
+    'BTC4H5MBot',
+    'apply_btc4h5m_strategy',
+    'generate_btc4h5m_signal',
+]
+
+from .trend_following import TrendFollowingBot, apply_strategy, generate_signal
+from .breakout_strategy import (
+    BreakoutStrategyBot,
+    apply_strategy as apply_breakout_strategy,
+    generate_signal as generate_breakout_signal,
+)
+from .mean_reversion import (
+    MeanReversionBot,
+    apply_strategy as apply_mean_reversion_strategy,
+    generate_signal as generate_mean_reversion_signal,
+)
+from .btc4h5m import (
+    BTC4H5MBot,
+    apply_strategy as apply_btc4h5m_strategy,
+    generate_signal as generate_btc4h5m_signal,
+)

--- a/STR_ONE/str_one/bots/breakout_strategy.py
+++ b/STR_ONE/str_one/bots/breakout_strategy.py
@@ -1,0 +1,89 @@
+"""Breakout strategy module using Donchian Channels.
+
+Provides utilities to compute breakout signals and a simple bot class to send
+signals to ``MetaNetManager``.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import numpy as np
+from typing import Dict
+
+
+def apply_strategy(df: pd.DataFrame, period: int = 20) -> pd.DataFrame:
+    """Calculate Donchian channel breakout signals on ``df``.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame with ``high``, ``low`` and ``close`` columns.
+    period : int, optional
+        Lookback window for the Donchian channels.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with ``upper_band``, ``lower_band`` and ``signal`` columns.
+    """
+    df = df.copy()
+    df["upper_band"] = df["high"].rolling(window=period).max()
+    df["lower_band"] = df["low"].rolling(window=period).min()
+    df["signal"] = 0
+    df["signal"] = np.where(
+        df["close"] > df["upper_band"].shift(1),
+        1,
+        np.where(df["close"] < df["lower_band"].shift(1), -1, 0),
+    )
+    return df
+
+
+def generate_signal(df: pd.DataFrame, asset: str = "BTCUSD", period: int = 20) -> Dict[str, object]:
+    """Generate a MetaNet-compatible signal dictionary from ``df``.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Price data with ``high``, ``low`` and ``close`` columns.
+    asset : str, optional
+        Asset identifier included in the resulting dictionary.
+    period : int, optional
+        Lookback period for Donchian channels.
+
+    Returns
+    -------
+    Dict[str, object]
+        Dictionary with ``asset``, ``score``, ``signal`` and ``confidence``.
+    """
+    result = apply_strategy(df, period)
+    last = result.iloc[-1]
+    if last["signal"] == 1:
+        score = float(last["close"] - last["upper_band"])
+    elif last["signal"] == -1:
+        score = float(last["lower_band"] - last["close"])
+    else:
+        score = 0.0
+    width = float(max(last["upper_band"] - last["lower_band"], 1e-8))
+    confidence = float(min(abs(score) / width, 1.0))
+    signal = "buy" if last["signal"] == 1 else "sell" if last["signal"] == -1 else "hold"
+    return {
+        "asset": asset,
+        "score": score,
+        "signal": signal,
+        "confidence": confidence,
+    }
+
+
+class BreakoutStrategyBot:
+    """Bot wrapper for the breakout strategy."""
+
+    def __init__(self, bot_id: str, manager, asset: str = "BTCUSD", period: int = 20) -> None:
+        self.bot_id = bot_id
+        self.manager = manager
+        self.asset = asset
+        self.period = period
+
+    def on_new_data(self, df: pd.DataFrame) -> None:
+        """Generate a signal from ``df`` and send it to ``MetaNetManager``."""
+        signal = generate_signal(df, self.asset, self.period)
+        self.manager.receive_signal(self.bot_id, signal)

--- a/STR_ONE/str_one/bots/btc4h5m.py
+++ b/STR_ONE/str_one/bots/btc4h5m.py
@@ -1,0 +1,96 @@
+"""Advanced BTC 4h/5m strategy bot.
+
+This module adapts the standalone `btc4h5m.py` trading script into a
+lightweight component compatible with ``MetaNetManager``. It calculates
+several technical indicators using the ``ta`` package and forwards a
+simplified trading signal to the manager.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import pandas as pd
+import ta
+
+
+@dataclass
+class StrategyParams:
+    """Configuration parameters for the strategy."""
+
+    atr_len: int = 14
+    rsi_len: int = 14
+    min_atr_pct: float = 0.0005
+    rsi_buy: int = 55
+    rsi_sell: int = 45
+
+
+def apply_strategy(df: pd.DataFrame, params: StrategyParams | None = None) -> pd.DataFrame:
+    """Compute indicators and trading signals on ``df``."""
+    if params is None:
+        params = StrategyParams()
+
+    df = df.copy()
+    df["atr"] = ta.volatility.average_true_range(df["high"], df["low"], df["close"], params.atr_len)
+    df["rsi"] = ta.momentum.rsi(df["close"], params.rsi_len)
+    df["ema20"] = ta.trend.ema_indicator(df["close"], 20)
+    df["ema50"] = ta.trend.ema_indicator(df["close"], 50)
+
+    df["atr_pct"] = df["atr"] / df["close"]
+    trend_up = (df["close"] > df["ema20"]) & (df["ema20"] > df["ema50"])
+    trend_down = (df["close"] < df["ema20"]) & (df["ema20"] < df["ema50"])
+
+    cond_long = (df["atr_pct"] > params.min_atr_pct) & (df["rsi"] > params.rsi_buy) & trend_up
+    cond_short = (df["atr_pct"] > params.min_atr_pct) & (df["rsi"] < params.rsi_sell) & trend_down
+
+    df["signal"] = 0
+    df.loc[cond_long, "signal"] = 1
+    df.loc[cond_short, "signal"] = -1
+
+    return df
+
+
+def generate_signal(
+    df: pd.DataFrame,
+    asset: str = "BTCUSD",
+    params: StrategyParams | None = None,
+) -> Dict[str, object]:
+    """Return a MetaNet-compatible signal dictionary from ``df``."""
+    result = apply_strategy(df, params)
+    last = result.iloc[-1]
+
+    sig_map = {1: "buy", -1: "sell", 0: "hold"}
+    signal = sig_map[int(last["signal"])]
+
+    score = float(last["rsi"] - 50.0)
+    width = float(max(last["atr_pct"], 1e-8))
+    confidence = float(min(abs(score) / max(width, 1e-6), 1.0))
+
+    return {
+        "asset": asset,
+        "score": score,
+        "signal": signal,
+        "confidence": confidence,
+    }
+
+
+class BTC4H5MBot:
+    """Bot wrapper around the improved BTC strategy."""
+
+    def __init__(
+        self,
+        bot_id: str,
+        manager,
+        asset: str = "BTCUSD",
+        params: StrategyParams | None = None,
+    ) -> None:
+        self.bot_id = bot_id
+        self.manager = manager
+        self.asset = asset
+        self.params = params or StrategyParams()
+
+    def on_new_data(self, df: pd.DataFrame) -> None:
+        """Generate a signal from ``df`` and send it to ``MetaNetManager``."""
+        signal = generate_signal(df, self.asset, self.params)
+        self.manager.receive_signal(self.bot_id, signal)

--- a/STR_ONE/str_one/bots/mean_reversion.py
+++ b/STR_ONE/str_one/bots/mean_reversion.py
@@ -1,0 +1,76 @@
+"""Mean Reversion strategy module using RSI and Bollinger Bands.
+
+Provides a helper function to compute a MetaNet-compatible signal and a bot
+class to dispatch it to ``MetaNetManager``.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import numpy as np
+from typing import Dict
+
+
+def rsi(series: pd.Series, period: int = 14) -> pd.Series:
+    """Compute the Relative Strength Index of ``series``."""
+    delta = series.diff()
+    gain = delta.where(delta > 0, 0).rolling(window=period).mean()
+    loss = (-delta.where(delta < 0, 0)).rolling(window=period).mean()
+    rs = gain / loss
+    return 100 - (100 / (1 + rs))
+
+
+def apply_strategy(df: pd.DataFrame, rsi_period: int = 5) -> pd.DataFrame:
+    """Calculate RSI and Bollinger Band signals on ``df``."""
+    df = df.copy()
+    df["rsi"] = rsi(df["close"], period=rsi_period)
+    df["ma20"] = df["close"].rolling(window=20).mean()
+    df["std"] = df["close"].rolling(window=20).std()
+    df["lower_bb"] = df["ma20"] - 2 * df["std"]
+    df["upper_bb"] = df["ma20"] + 2 * df["std"]
+    df["signal"] = np.where(
+        (df["rsi"] < 30) & (df["close"] < df["lower_bb"]),
+        1,
+        np.where(
+            (df["rsi"] > 70) & (df["close"] > df["upper_bb"]),
+            -1,
+            0,
+        ),
+    )
+    return df
+
+
+def generate_signal(df: pd.DataFrame, asset: str = "BTCUSD", rsi_period: int = 5) -> Dict[str, object]:
+    """Generate a signal dictionary from ``df`` for ``MetaNetManager``."""
+    result = apply_strategy(df, rsi_period)
+    last = result.iloc[-1]
+    if last["signal"] == 1:
+        score = float(last["ma20"] - last["close"])
+    elif last["signal"] == -1:
+        score = float(last["close"] - last["ma20"])
+    else:
+        score = 0.0
+    width = float(max(last["upper_bb"] - last["lower_bb"], 1e-8))
+    confidence = float(min(abs(score) / width, 1.0))
+    signal = "buy" if last["signal"] == 1 else "sell" if last["signal"] == -1 else "hold"
+    return {
+        "asset": asset,
+        "score": score,
+        "signal": signal,
+        "confidence": confidence,
+    }
+
+
+class MeanReversionBot:
+    """Bot wrapper around the mean reversion strategy."""
+
+    def __init__(self, bot_id: str, manager, asset: str = "BTCUSD", rsi_period: int = 5) -> None:
+        self.bot_id = bot_id
+        self.manager = manager
+        self.asset = asset
+        self.rsi_period = rsi_period
+
+    def on_new_data(self, df: pd.DataFrame) -> None:
+        """Create a signal from ``df`` and forward it to ``MetaNetManager``."""
+        signal = generate_signal(df, self.asset, self.rsi_period)
+        self.manager.receive_signal(self.bot_id, signal)

--- a/STR_ONE/str_one/bots/trend_following.py
+++ b/STR_ONE/str_one/bots/trend_following.py
@@ -1,0 +1,85 @@
+"""Trend Following strategy module.
+
+Implements a simple moving average crossover approach and exposes a helper
+function to generate a MetaNet-compatible signal dictionary.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import numpy as np
+from typing import Dict
+
+
+def apply_strategy(df: pd.DataFrame, short_window: int = 20, long_window: int = 50) -> pd.DataFrame:
+    """Calculate moving average cross signals on ``df``.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame with a ``close`` column.
+    short_window : int, optional
+        Period for the short moving average.
+    long_window : int, optional
+        Period for the long moving average.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with ``ma_short``, ``ma_long`` and ``signal`` columns.
+    """
+    df = df.copy()
+    df["ma_short"] = df["close"].rolling(window=short_window).mean()
+    df["ma_long"] = df["close"].rolling(window=long_window).mean()
+    df["signal"] = 0
+    df.loc[short_window:, "signal"] = np.where(
+        df["ma_short"][short_window:] > df["ma_long"][short_window:], 1, -1
+    )
+    return df
+
+
+def generate_signal(df: pd.DataFrame, asset: str = "BTCUSD", short_window: int = 20, long_window: int = 50) -> Dict[str, object]:
+    """Generate a signal dictionary for ``MetaNetManager`` from ``df``.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Price data with a ``close`` column.
+    asset : str, optional
+        Asset identifier included in the resulting dictionary.
+    short_window : int, optional
+        Short moving average window.
+    long_window : int, optional
+        Long moving average window.
+
+    Returns
+    -------
+    Dict[str, object]
+        Dictionary with ``asset``, ``score``, ``signal`` and ``confidence``.
+    """
+    result = apply_strategy(df, short_window, long_window)
+    last_row = result.iloc[-1]
+    score = float(last_row["ma_short"] - last_row["ma_long"])
+    signal = "buy" if last_row["signal"] > 0 else "sell"
+    confidence = float(min(abs(score) / max(last_row["ma_long"], 1.0), 1.0))
+    return {
+        "asset": asset,
+        "score": score,
+        "signal": signal,
+        "confidence": confidence,
+    }
+
+class TrendFollowingBot:
+    """Simple bot wrapping the trend following strategy."""
+
+    def __init__(self, bot_id: str, manager, asset: str = "BTCUSD", short_window: int = 20, long_window: int = 50) -> None:
+        self.bot_id = bot_id
+        self.manager = manager
+        self.asset = asset
+        self.short_window = short_window
+        self.long_window = long_window
+
+    def on_new_data(self, df: pd.DataFrame) -> None:
+        """Generate a signal from ``df`` and send it to ``MetaNetManager``."""
+        signal = generate_signal(df, self.asset, self.short_window, self.long_window)
+        self.manager.receive_signal(self.bot_id, signal)

--- a/STR_ONE/str_one/metanet_manager.py
+++ b/STR_ONE/str_one/metanet_manager.py
@@ -1,0 +1,134 @@
+"""MetaNet manager module.
+
+This module manages up to 99 subordinate trading bots, collects their signals
+and computes a weighted global signal for the MetaNet head bot.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BotSignal:
+    """Container for a bot signal."""
+
+    asset: str
+    score: float
+    signal: str
+    confidence: float
+    weight: float = 1.0
+
+
+class MetaNetManager:
+    """Manage the collection and aggregation of bot signals."""
+
+    def __init__(self) -> None:
+        # Initialize slots for 99 bots (bot_01 .. bot_99)
+        self.bot_ids: List[str] = [f"bot_{i:02d}" for i in range(1, 100)]
+        self.signals: Dict[str, Optional[BotSignal]] = {
+            bot_id: None for bot_id in self.bot_ids
+        }
+        logger.debug("Initialized manager with %d bots", len(self.bot_ids))
+
+    def reset_signals(self) -> None:
+        """Resetta tutti i segnali ricevuti, riportandoli a ``None``."""
+        for bot_id in self.bot_ids:
+            self.signals[bot_id] = None
+        logger.info("Reset dei segnali effettuato.")
+
+    def get_signals_state(self) -> Dict[str, Optional[BotSignal]]:
+        """Restituisce lo stato attuale dei segnali ricevuti."""
+        return self.signals
+
+    def receive_signal(self, bot_id: str, signal_dict: Dict[str, object]) -> None:
+        """Store the signal from a bot.
+
+        Parameters
+        ----------
+        bot_id: str
+            Identifier of the sending bot (e.g. ``"bot_01"``).
+        signal_dict: Dict[str, object]
+            Dictionary containing ``asset``, ``score``, ``signal`` and
+            ``confidence`` keys.
+        """
+        if bot_id not in self.signals:
+            logger.warning("Unknown bot_id: %s", bot_id)
+            return
+
+        try:
+            signal = BotSignal(
+                asset=str(signal_dict["asset"]),
+                score=float(signal_dict.get("score", 0.0)),
+                signal=str(signal_dict.get("signal", "hold")),
+                confidence=float(signal_dict.get("confidence", 1.0)),
+            )
+        except KeyError as exc:
+            logger.error("Missing key in signal from %s: %s", bot_id, exc)
+            return
+
+        self.signals[bot_id] = signal
+        logger.info("Received signal from %s: %s", bot_id, signal_dict)
+
+    def compute_global_signal(self) -> Dict[str, object]:
+        """Compute the weighted average score and aggregated decision.
+
+        Returns
+        -------
+        Dict[str, object]
+            Dictionary with ``weighted_score`` and ``aggregated_signal``.
+        """
+        total_weight = 0.0
+        weighted_score = 0.0
+        decision_votes = {"buy": 0.0, "sell": 0.0, "hold": 0.0}
+
+        for bot_id, signal in self.signals.items():
+            if signal is None:
+                continue
+            w = signal.weight * signal.confidence
+            total_weight += w
+            weighted_score += signal.score * w
+            decision_votes[signal.signal] = decision_votes.get(signal.signal, 0.0) + w
+
+        if total_weight == 0.0:
+            result = {"weighted_score": 0.0, "aggregated_signal": "hold"}
+        else:
+            avg_score = weighted_score / total_weight
+            agg_signal = max(decision_votes, key=decision_votes.get)
+            result = {
+                "weighted_score": round(avg_score, 4),
+                "aggregated_signal": agg_signal,
+            }
+
+        logger.info("Computed global signal: %s", result)
+        return result
+
+
+# Module-level manager instance
+_manager = MetaNetManager()
+
+
+def receive_signal(bot_id: str, signal_dict: Dict[str, object]) -> None:
+    """Public API to send a signal to the module-level manager."""
+    _manager.receive_signal(bot_id, signal_dict)
+
+
+def compute_global_signal() -> str:
+    """Return the aggregated signal as a JSON string."""
+    result = _manager.compute_global_signal()
+    return json.dumps(result)
+
+
+def reset_signals() -> None:
+    """Public API to reset all signals in the manager."""
+    _manager.reset_signals()
+
+
+def get_signals_state() -> Dict[str, Optional[BotSignal]]:
+    """Public API to obtain the current internal state of signals."""
+    return _manager.get_signals_state()


### PR DESCRIPTION
## Summary
- integrate a BTC 4h/5m strategy bot compatible with MetaNetManager
- expose the new bot and helpers in the package
- mention the advanced bot in the README

## Testing
- `python -m py_compile STR_ONE/str_one/*.py STR_ONE/str_one/bots/*.py META_NET/meta_net/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6841bb4cbb188327bcaa1adce289b0f0