### PR TITLE
Add tests for MetaNetManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ included ``TrendFollowingBot``, ``BreakoutStrategyBot`` and ``MeanReversionBot``
 demonstrate how to feed signals into the manager. A more advanced example,
 ``BTC4H5MBot``, shows how to adapt a real trading script to the same
 interface.
+
+## Running tests
+
+Execute the test suite with::
+
+    python -m unittest

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,0 +1,33 @@
+import json
+import unittest
+import importlib.util
+import sys
+from pathlib import Path
+
+# Load metanet_manager module directly to avoid importing optional deps
+MANAGER_PATH = Path(__file__).resolve().parents[1] / 'STR_ONE' / 'str_one' / 'metanet_manager.py'
+spec = importlib.util.spec_from_file_location('metanet_manager', MANAGER_PATH)
+metanet_manager = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = metanet_manager
+spec.loader.exec_module(metanet_manager)
+
+receive_signal = metanet_manager.receive_signal
+compute_global_signal = metanet_manager.compute_global_signal
+reset_signals = metanet_manager.reset_signals
+
+class TestMetaNetManager(unittest.TestCase):
+    def tearDown(self):
+        reset_signals()
+
+    def test_weighted_signal(self):
+        reset_signals()
+        receive_signal('bot_01', {'asset': 'BTCUSD', 'score': 0.5, 'signal': 'buy', 'confidence': 1.0})
+        receive_signal('bot_02', {'asset': 'BTCUSD', 'score': -0.2, 'signal': 'sell', 'confidence': 0.5})
+        receive_signal('bot_03', {'asset': 'BTCUSD', 'score': 0.1, 'signal': 'buy', 'confidence': 1.0})
+
+        result = json.loads(compute_global_signal())
+        expected = {'weighted_score': 0.2, 'aggregated_signal': 'buy'}
+        self.assertEqual(result, expected)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a unit test checking weighted signal aggregation
- document running tests with `python -m unittest`

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_68499cc672688327bde433f6d035f6cf